### PR TITLE
azurerm_container_app - Add documentation for custom domain block within the ingress block

### DIFF
--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -287,6 +287,16 @@ An `ingress` block supports the following:
 
 ---
 
+A `custom_domain` block supports the following:
+
+* `certificate_binding_type` - (Optional) The Binding type. Possible values include `Disabled` and `SniEnabled`. Defaults to `Disabled`.
+
+* `certificate_id` - (Required) The ID of the Container App Environment Certificate.
+
+* `name` - (Required) The hostname of the Certificate. Must be the CN or a named SAN in the certificate.
+
+---
+
 A `traffic_weight` block supports the following:
 
 ~> **Note:** This block only applies when `revision_mode` is set to `Multiple`.


### PR DESCRIPTION
Adding the `custom_domain` block information to the docs which is currently missing.